### PR TITLE
Make changetab script fully generic

### DIFF
--- a/changetab.js
+++ b/changetab.js
@@ -1,33 +1,45 @@
-$('.top.menu .item').tab();
+$(".top.menu .item").tab();
 
-function change(tabnr) {
-  if (tabnr == 1) {
-    $('div').removeClass("active");
-    $('#allgemein').addClass("active");
+/**
+ * This code is run as soon as the page is fully loaded.
+ * It will find all tabs and their corresponding menu items.
+ * It will add an onclick listener to the menu items so you
+ * can click them to change the active tab.
+ */
+$(function() {
+  let tabs = $(".tab");
+  let containers = $(".con");
+  let menuItems = $(".menu .item");
+  // The container containing all chart containers
+  let chartContainerContainer = $("#chartcontainer");
 
-    $('a').removeClass("active");
-    $('#allgemeintab').addClass("active");
+  menuItems.on("click", function(event) {
+    // The newly selected menu item is the target of this on click event
+    let newlySelectedItem = $(event.currentTarget);
+    // The item stores the name of the corresponding tab in the data-tab attribute,
+    // so we can use it to determine both the tab and the chart container
+    let newlySelectedTabName = newlySelectedItem.attr("data-tab");
+    let newlySelectedTab = $("#"+newlySelectedTabName);
+    let newlySelectedContainer = $("#"+newlySelectedTabName+"container");
 
-    $('#chartcontainer').hide();
-  } else if (tabnr == 2) {
-    $('div').removeClass("active");
-    $('#einnahmen').addClass("active");
+    // If the "length" of newlySelectedContainer is 0, it means there is no such
+    // container. In this case, we also hide the chart container container, otherwise, we show it
+    if(newlySelectedContainer.length == 0) {
+      chartContainerContainer.hide();
+    } else {
+      chartContainerContainer.show();
+    }
+    
+    // First, remove the active class from all tabs and menu items
+    // and hide all containers
+    tabs.removeClass("active");
+    menuItems.removeClass("active");
+    containers.hide();
 
-    $('a').removeClass("active");
-    $('#einnahmentab').addClass("active");
-
-    $('#ausgabencontainer').hide();
-    $('#chartcontainer').show();
-    $('#einnahmencontainer').show();
-  } else if (tabnr == 3) {
-    $('div').removeClass("active");
-    $('#ausgaben').addClass("active");
-
-    $('a').removeClass("active");
-    $('#ausgabentab').addClass("active");
-
-    $('#einnahmencontainer').hide();
-    $('#chartcontainer').show();
-    $('#ausgabencontainer').show();
-  }
-}
+    // Then, add it back to only the selected tab and its menu item
+    // and the corresponding chart container
+    newlySelectedItem.addClass("active");
+    newlySelectedTab.addClass("active");
+    newlySelectedContainer.show();
+  });
+});

--- a/index.html
+++ b/index.html
@@ -57,9 +57,9 @@
             </div>
 
             <div class="ui top attached tabular menu">
-                <a id="allgemeintab" onclick="change(1)" class="item active" data-tab="allgemein">Allgemein</a>
-                <a id="einnahmentab" onclick="change(2)" class="item" data-tab="einnahmen">Einnahmen</a>
-                <a id="ausgabentab" onclick="change(3)" class="item" data-tab="ausgaben">Ausgaben</a>
+                <a id="allgemeintab" class="item active" data-tab="allgemein">Allgemein</a>
+                <a id="einnahmentab" class="item" data-tab="einnahmen">Einnahmen</a>
+                <a id="ausgabentab" class="item" data-tab="ausgaben">Ausgaben</a>
             </div>
 
             <div id="allgemein" data-tab="allgemein" class="ui bottom attached active tab segment">
@@ -105,7 +105,6 @@
         </div>
         <div class="column">
             <div id="chartcontainer" hidden="true" class="ui segment">
-                <div class="con" id="allgemeincontainer"></div>
                 <div class="con" id="einnahmencontainer"></div>
                 <div class="con" id="ausgabencontainer"></div>
             </div>

--- a/style.css
+++ b/style.css
@@ -79,14 +79,6 @@ tspan {
     position: absolute;
 }
 
-#einnahmencontainer {
-    display: none;
-}
-
-#ausgabencontainer {
-    display: none;
-}
-
 #screen {
     padding: 20px;
 }


### PR DESCRIPTION
`changetab.js` is now fully generic and doesn't need to be changed when a new tab is introduced. How to introduce a new tab?

1. Add a menu item: 
    ```html
    <a id="somethingtab" class="item" data-tab="something">Irgendetwas</a>
    ```
2. Add a tab with an id matching the `data-tab` attribute of the menu item:
    ```html
    <div id="something" data-tab="something" class="ui bottom attached tab segment">
       [...]
    </div>
    ```
3. Optionally, add a chart container (if you don't, the chart container container will be hidden when selecting the tab and shown whenever needed for other tabs):
    ```html
    <div class="con" id="somethingcontainer"></div>
    ```