### PR TITLE
Liste der uns bekannten Instanzen hinzufügen

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,11 @@ Möglichkeiten, um einen temporären Webserver zu starten:
 
 * [Pythons `http.server`-Modul](https://docs.python.org/3/library/http.server.html) (weiter unten auf der verlinkten Website befindet sich der Befehl zum direkten Starten des Servers auf der Kommandozeile)
 * [npm `static-server` Modul](https://www.npmjs.com/package/static-server#getting-started) (einfach global installieren und dann im gewünschten Verzeichnis, also auf der Ebene der `index.html` den Befehl `static-server` ausführen)
+
+## Aktive Instanzen
+
+Instanzen des Finance-Visualizers, von denen wir wissen. Fühlt euch frei, eure eigenen Instanzen über einen Pull Request der Liste hinzuzufügen:
+
+* [Fachschaftshaushalt MathPhysInfo](https://mathphys.stura.uni-heidelberg.de/finanzen/)
+* [Fachschaftshaushalt Computerlinguistik](https://finanzen.fachschaft.cl.uni-heidelberg.de/)
+


### PR DESCRIPTION
War nur so eine Überlegung von mir, fühlt euch frei, den Request zu schließen, wenn ihr ihn für unpassend haltet:

Ich fände es ganz nett, eine Liste der aktiven Instanzen im README zu haben, um einen Eindruck davon zu bekommen, wo die Software überall verwendet wird.

Ich weiß aktuell von diesen zwei Instanzen hier.