### PR TITLE
resize charts

### DIFF
--- a/js/display.js
+++ b/js/display.js
@@ -49,6 +49,8 @@ function makeColor(data, displaytext) {
   }
 }
 
+export var einnahmenChart, ausgabenChart
+
 export function show(balanceSheet) {
   makeColor(balanceSheet.einnahmen, function() { displayEinnahmenEntry(this) })
   makeColor(balanceSheet.ausgaben, function() { displayAusgabenEntry(this) })
@@ -91,7 +93,7 @@ export function show(balanceSheet) {
   // Splice in transparent for the center circle
   Highcharts.getOptions().colors.splice(0, 0, 'transparent');
 
-  Highcharts.chart('ausgabencontainer', {
+  ausgabenChart = Highcharts.chart('ausgabencontainer', {
     chart: {
       height: '100%'
     },
@@ -148,7 +150,7 @@ export function show(balanceSheet) {
   // Splice in transparent for the center circle
   Highcharts.getOptions().colors.splice(0, 0, 'transparent');
 
-  Highcharts.chart('einnahmencontainer', {
+  einnahmenChart = Highcharts.chart('einnahmencontainer', {
 
     chart: {
       height: '100%'

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -1,3 +1,5 @@
+import * as display from "./display.js"
+
 /**
  * Finds all tabs and their corresponding menu items.
  * Adds an onclick listener to the menu items so you
@@ -40,5 +42,11 @@ export function initialize() {
     newlySelectedItem.addClass("active");
     newlySelectedTab.addClass("active");
     newlySelectedContainer.show();
+
+    if (newlySelectedTabName == "einnahmen") {
+      display.einnahmenChart.reflow();
+    } else if (newlySelectedTabName == "ausgaben") {
+      display.ausgabenChart.reflow();
+    }
   });
 }


### PR DESCRIPTION
closes #12.
Das Problem war, dass sich die Containergröße nur ändert, wenn er sichtbar ist. Deshalb rufe ich jetzt `Chart.reflow()` auf, sobald der Container wieder sichtbar ist.