### PR TITLE
Use location.replace() instead of location.hash =

### DIFF
--- a/js/yearSwitcher.js
+++ b/js/yearSwitcher.js
@@ -16,7 +16,7 @@ let hash = {
     return parseIntOrNull(window.location.hash.substring(1));
   },
   setYear: function (year) {
-    window.location.hash = year;
+    window.location.replace("#"+year);
   },
 
   /**


### PR DESCRIPTION
This won't push hash change events into the browser history, creating a more natural browsing experience.

Furthermore it fixes a bug that wouldn't let you leave the site if you initially accessed it without a hash fragment.